### PR TITLE
Atom pairs implementation

### DIFF
--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -68,9 +68,10 @@ std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract,
   code |= typeIdx << (numBranchBits + numPiBits);
   code |= cipCodeBits << (numBranchBits + numPiBits + numTypeBits);
 
-  POSTCONDITION(code < static_cast<std::uint32_t>(
-                           1 << (codeSize + (includeChirality ? numChiralBits : 0))),
-                "code exceeds number of bits");
+  POSTCONDITION(
+      code < static_cast<std::uint32_t>(
+                 1 << (codeSize + (includeChirality ? numChiralBits : 0))),
+      "code exceeds number of bits");
   return code;
 };
 
@@ -85,8 +86,8 @@ std::uint32_t getAtomPairCode(std::uint32_t codeI, std::uint32_t codeJ,
 }
 
 std::uint64_t AtomPairArguments::getResultSize() const {
-  return (
-      1 << (numAtomPairFingerprintBits + 2 * (df_includeChirality ? numChiralBits : 0)));
+  return (1 << (numAtomPairFingerprintBits +
+                2 * (df_includeChirality ? numChiralBits : 0)));
 }
 
 AtomPairArguments::AtomPairArguments(const bool countSimulation,
@@ -195,7 +196,7 @@ std::vector<AtomEnvironment *> AtomPairEnvGenerator::getEnvironments(
   return result;
 }
 
-FingerprintGenerator getAtomPairGenerator(
+FingerprintGenerator *getAtomPairGenerator(
     const unsigned int minDistance, const unsigned int maxDistance,
     const bool includeChirality, const bool use2D,
     const bool useCountSimulation,
@@ -206,8 +207,9 @@ FingerprintGenerator getAtomPairGenerator(
   FingerprintArguments *atomPairArguments = new AtomPair::AtomPairArguments(
       useCountSimulation, includeChirality, use2D, minDistance, maxDistance);
 
-  return FingerprintGenerator(atomPairEnvGenerator, atomPairArguments,
-                              atomInvariantsGenerator, bondInvariantsGenerator);
+  return new FingerprintGenerator(atomPairEnvGenerator, atomPairArguments,
+                                  atomInvariantsGenerator,
+                                  bondInvariantsGenerator);
 }
 
 }  // namespace AtomPair

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -1,0 +1,238 @@
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Fingerprints/FingerprintGenerator.h>
+#include <GraphMol/Fingerprints/AtomPairGenerator.h>
+
+namespace RDKit {
+namespace AtomPair {
+
+unsigned int numPiElectrons(const Atom *atom) {
+  PRECONDITION(atom, "no atom");
+  unsigned int res = 0;
+  if (atom->getIsAromatic()) {
+    res = 1;
+  } else if (atom->getHybridization() != Atom::SP3) {
+    unsigned int val = static_cast<unsigned int>(atom->getExplicitValence());
+    val -= atom->getNumExplicitHs();
+    CHECK_INVARIANT(val >= atom->getDegree(),
+                    "explicit valence exceeds atom degree");
+    res = val - atom->getDegree();
+  }
+  return res;
+}
+
+boost::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract,
+                            bool includeChirality) {
+  PRECONDITION(atom, "no atom");
+  boost::uint32_t code;
+
+  unsigned int numBranches = 0;
+  if (atom->getDegree() > branchSubtract) {
+    numBranches = atom->getDegree() - branchSubtract;
+  }
+
+  code = numBranches % maxNumBranches;
+  unsigned int nPi = numPiElectrons(atom) % maxNumPi;
+  code |= nPi << numBranchBits;
+
+  unsigned int typeIdx = 0;
+  unsigned int nTypes = 1 << numTypeBits;
+  while (typeIdx < nTypes) {
+    if (atomNumberTypes[typeIdx] ==
+        static_cast<unsigned int>(atom->getAtomicNum())) {
+      break;
+    } else if (atomNumberTypes[typeIdx] >
+               static_cast<unsigned int>(atom->getAtomicNum())) {
+      typeIdx = nTypes;
+      break;
+    }
+    ++typeIdx;
+  }
+  if (typeIdx == nTypes) --typeIdx;
+  code |= typeIdx << (numBranchBits + numPiBits);
+  if (includeChirality) {
+    std::string cipCode;
+    if (atom->getPropIfPresent(common_properties::_CIPCode, cipCode)) {
+      boost::uint32_t offset = numBranchBits + numPiBits + numTypeBits;
+      if (cipCode == "R") {
+        code |= 1 << offset;
+      } else if (cipCode == "S") {
+        code |= 2 << offset;
+      }
+    }
+  }
+  POSTCONDITION(code < static_cast<boost::uint32_t>(
+                           1 << (codeSize + (includeChirality ? 2 : 0))),
+                "code exceeds number of bits");
+  return code;
+};
+
+boost::uint32_t getAtomPairCode(boost::uint32_t codeI, boost::uint32_t codeJ,
+                                unsigned int dist, bool includeChirality) {
+  PRECONDITION(dist < maxPathLen, "dist too long");
+  boost::uint32_t res = dist;
+  res |= std::min(codeI, codeJ) << numPathBits;
+  res |= std::max(codeI, codeJ)
+         << (numPathBits + codeSize + (includeChirality ? numChiralBits : 0));
+  return res;
+}
+
+// AtomPairArguments
+
+unsigned int AtomPairArguments::getResultSize() const {
+  return (1 << (numAtomPairFingerprintBits + 2 * (includeChirality ? 2 : 0)));
+}
+
+AtomPairArguments::AtomPairArguments(const bool countSimulation,
+                                     const bool includeChirality,
+                                     const bool use2D,
+                                     const unsigned int minDistance,
+                                     const unsigned int maxDistance)
+    : FingerprintArguments(countSimulation),
+      includeChirality(includeChirality),
+      use2D(use2D),
+      minDistance(minDistance),
+      maxDistance(maxDistance) {
+  PRECONDITION(minDistance <= maxDistance, "bad distances provided");
+};
+
+// AtomPairAtomEnv
+
+boost::uint32_t AtomPairAtomEnv::getBitId(
+    AtomPairArguments arguments,
+    const std::vector<boost::uint32_t> *atomInvariants,
+    const std::vector<boost::uint32_t> *bondInvariants) const {
+  return getAtomPairCode(atomCodeCache->at(atomIdFirst),
+                         atomCodeCache->at(atomIdSecond), distance,
+                         arguments.includeChirality);
+}
+
+const std::vector<boost::uint32_t> *AtomPairAtomEnv::getAtomCodeCache() const {
+  return atomCodeCache;
+}
+
+AtomPairAtomEnv::AtomPairAtomEnv(
+    const std::vector<boost::uint32_t> *atomCodeCache,
+    const unsigned int atomIdFirst, const unsigned int atomIdSecond,
+    const unsigned int distance)
+    : atomCodeCache(atomCodeCache),
+      atomIdFirst(atomIdFirst),
+      atomIdSecond(atomIdSecond),
+      distance(distance) {}
+
+// AtomPairEnvGenerator
+
+std::vector<AtomPairAtomEnv> AtomPairEnvGenerator::getEnvironments(
+    const ROMol &mol, const AtomPairArguments arguments,
+    const std::vector<boost::uint32_t> *fromAtoms,
+    const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
+    const AdditionalOutput *additionalOutput,
+    const std::vector<boost::uint32_t> *atomInvariants,
+    const std::vector<boost::uint32_t> *bondInvariants) const {
+  PRECONDITION(!atomInvariants || atomInvariants->size() >= mol.getNumAtoms(),
+               "bad atomInvariants size");
+
+  std::vector<AtomPairAtomEnv> result = std::vector<AtomPairAtomEnv>();
+  const double *distanceMatrix;
+  if (arguments.use2D) {
+    distanceMatrix = MolOps::getDistanceMat(mol);
+  } else {
+    distanceMatrix = MolOps::get3DDistanceMat(mol, confId);
+  }
+
+  const unsigned int atomCount = mol.getNumAtoms();
+
+  std::vector<boost::uint32_t> *atomCodeCache =
+      new std::vector<boost::uint32_t>();
+  for (ROMol::ConstAtomIterator atomItI = mol.beginAtoms();
+       atomItI != mol.endAtoms(); ++atomItI) {
+    if (!atomInvariants) {
+      atomCodeCache->push_back(
+          getAtomCode(*atomItI, 0, arguments.includeChirality));
+    } else {
+      atomCodeCache->push_back((*atomInvariants)[(*atomItI)->getIdx()] %
+                               ((1 << codeSize) - 1));
+    }
+
+    for (ROMol::ConstAtomIterator atomItI = mol.beginAtoms();
+         atomItI != mol.endAtoms(); ++atomItI) {
+      unsigned int i = (*atomItI)->getIdx();
+      if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
+                                   i) != ignoreAtoms->end()) {
+        continue;
+      }
+
+      for (ROMol::ConstAtomIterator atomItJ = atomItI + 1;
+           atomItJ != mol.endAtoms(); ++atomItJ) {
+        unsigned int j = (*atomItJ)->getIdx();
+        if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
+                                     j) != ignoreAtoms->end()) {
+          continue;
+        }
+
+        if (fromAtoms &&
+            (std::find(fromAtoms->begin(), fromAtoms->end(), i) ==
+             fromAtoms->end()) &&
+            (std::find(fromAtoms->begin(), fromAtoms->end(), j) ==
+             fromAtoms->end())) {
+          continue;
+        }
+        unsigned int distance =
+            static_cast<unsigned int>(floor(distanceMatrix[i * atomCount + j]));
+
+        if (distance >= arguments.minDistance &&
+            distance <= arguments.maxDistance) {
+          result.push_back(AtomPairAtomEnv(atomCodeCache, i, j, distance));
+        }
+      }
+    }
+  }
+
+  if (result.empty()) {
+    // cleanUpEnvironments will not be able to clear shared resources since the
+    // result is empty so we do it here
+    delete atomCodeCache;
+  }
+
+  return std::vector<AtomPairAtomEnv>();
+};
+
+void AtomPairEnvGenerator::cleanUpEnvironments(
+    const std::vector<AtomPairAtomEnv> &atomEnvironments) const {
+  if (!atomEnvironments.empty()) {
+    delete atomEnvironments[0].getAtomCodeCache();
+  }
+}
+
+FingerprintGenerator<AtomPairEnvGenerator, AtomPairArguments, AtomPairAtomEnv>
+getAtomPairGenerator(const ROMol &mol, const unsigned int minDistance,
+                     const unsigned int maxDistance,
+                     const bool includeChirality, const bool use2D,
+                     const bool useCountSimulation,
+                     AtomInvariantsGenerator *atomInvariantsGenerator = 0,
+                     BondInvariantsGenerator *bondInvariantsGenerator = 0) {
+  AtomPairArguments atomPairArguments = AtomPairArguments(
+      useCountSimulation, includeChirality, use2D, minDistance, maxDistance);
+  AtomPairEnvGenerator atomPairEnvGenerator = AtomPairEnvGenerator();
+
+  return FingerprintGenerator<AtomPairEnvGenerator, AtomPairArguments,
+                              AtomPairAtomEnv>(
+      atomPairEnvGenerator, atomPairArguments, atomInvariantsGenerator,
+      bondInvariantsGenerator);
+}
+}  // namespace AtomPair
+
+template<>
+FingerprintGenerator<AtomPair::AtomPairEnvGenerator,
+                     AtomPair::AtomPairArguments, AtomPair::AtomPairAtomEnv>::
+    FingerprintGenerator(
+        AtomPair::AtomPairEnvGenerator atomEnvironmentGenerator,
+        AtomPair::AtomPairArguments fingerprintArguments,
+        AtomInvariantsGenerator *atomInvariantsGenerator,
+        BondInvariantsGenerator *bondInvariantsGenerator) {
+  this->atomEnvironmentGenerator = atomEnvironmentGenerator;
+  this->fingerprintArguments = fingerprintArguments;
+  this->asCommonArguments = &this->fingerprintArguments;
+  this->atomInvariantsGenerator = atomInvariantsGenerator;
+  this->bondInvariantsGenerator = bondInvariantsGenerator;
+}
+}  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -20,45 +20,49 @@ const unsigned int numPathBits = 5;
 const unsigned int maxPathLen = (1 << numPathBits) - 1;
 const unsigned int numAtomPairFingerprintBits = numPathBits + 2 * codeSize;
 
-/*
-Class that holds atom pair fingerprinting arguments
-includeChirality: if set, chirality will be used in the atom invariants (note:
-this is ignored if atomInvariantsGenerator is present for the fingerprint
-generator that uses this)
-use2D: if set, the 2D (topological) distance matrix is used
-minDistance: minimum distance between atoms to be considered in a pair. Default
-is 1 bond.
-maxDistance: maximum distance between atoms to be considered in a pair. Default
-is maxPathLen-1 bonds
-*/
+/*!
+  /brief class that holds atom-pair fingerprint specific arguments
+
+ */
 class AtomPairArguments : public FingerprintArguments {
  public:
-  const bool includeChirality;
-  const bool use2D;
-  const unsigned int minDistance;
-  const unsigned int maxDistance;
+  const bool df_includeChirality;
+  const bool df_use2D;
+  const unsigned int d_minDistance;
+  const unsigned int d_maxDistance;
 
-  unsigned int getResultSize() const;
+  boost::uint64_t getResultSize() const;
 
+  /*!
+    /brief construct a new AtomPairArguments object
+
+    /param countSimulation  if set, use count simulation while generating the
+    fingerprint
+    /param includeChirality if set, chirality will be used in the atom
+    invariants, this is ignored if atomInvariantsGenerator is present for
+    the /c FingerprintGenerator that uses this
+    /param use2D            if set, the 2D (topological) distance matrix will be
+    used
+    /param minDistance      minimum distance between atoms to be considered in a
+    pair, default is 1 bond
+    /param maxDistance      maximum distance between atoms to be considered in a
+    pair, default is maxPathLen-1 bonds
+   */
   AtomPairArguments(const bool countSimulation, const bool includeChirality,
                     const bool use2D, const unsigned int minDistance = 1,
                     const unsigned int maxDistance = (maxPathLen - 1));
 };
 
-/*
-Class to hold atom environment data for atom pair fingerprinting
-atomCodeCache: list of atom codes for all atoms in the molecule, used to avoid
-generating atom code for the same atom multiple times. This is deleted by
-calling AtomPairEnvGenerator::cleanUpEnvironments
-atomIdFirst: index of the first atom of the pair
-atomIdSecond: index of the second atom of the pair
-distance: distance between the atoms
-*/
+/*!
+  /brief class that holds atom-environment data needed for atom-pair fingerprint
+  generation
+
+ */
 class AtomPairAtomEnv : public AtomEnvironment {
   const std::vector<boost::uint32_t> *atomCodeCache;
-  const unsigned int atomIdFirst;
-  const unsigned int atomIdSecond;
-  const unsigned int distance;
+  const unsigned int d_atomIdFirst;
+  const unsigned int d_atomIdSecond;
+  const unsigned int d_distance;
 
  public:
   boost::uint32_t getBitId(
@@ -66,41 +70,67 @@ class AtomPairAtomEnv : public AtomEnvironment {
       const std::vector<boost::uint32_t> *atomInvariants,
       const std::vector<boost::uint32_t> *bondInvariants) const;
 
-  /*
-  returns a pointer to the atom code cache so it can be deleted
-  */
   const std::vector<boost::uint32_t> *getAtomCodeCache() const;
 
+  /*!
+    /brief construct a new AtomPairAtomEnv object
+
+    /param atomIdFirst  id of the first atom of the atom-pair
+    /param atomIdSecond id of the second atom of the atom-pair
+    /param distance     distance between the atoms
+   */
   AtomPairAtomEnv(const std::vector<boost::uint32_t> *atomCodeCache,
                   const unsigned int atomIdFirst,
                   const unsigned int atomIdSecond, const unsigned int distance);
 };
 
-/*
-Class to generate atom environments from a molecule to be used for atom pair
-fingerprinting
-*/
+/*!
+  /brief class that generates atom-environments for atom-pair fingerprint
+
+ */
 class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
  public:
   std::vector<AtomEnvironment *> getEnvironments(
       const ROMol &mol, FingerprintArguments *arguments,
-      const std::vector<boost::uint32_t> *fromAtoms = 0,
-      const std::vector<boost::uint32_t> *ignoreAtoms = 0,
-      const int confId = -1, const AdditionalOutput *additionalOutput = 0,
-      const std::vector<boost::uint32_t> *atomInvariants = 0,
-      const std::vector<boost::uint32_t> *bondInvariants = 0) const;
+      const std::vector<boost::uint32_t> *fromAtoms = nullptr,
+      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+      const int confId = -1, const AdditionalOutput *additionalOutput = nullptr,
+      const std::vector<boost::uint32_t> *atomInvariants = nullptr,
+      const std::vector<boost::uint32_t> *bondInvariants = nullptr) const;
 
   void cleanUpEnvironments(
       std::vector<AtomEnvironment *> atomEnvironments) const;
 };
 
+/*!
+  /brief helper function that generates a /c FingerprintGenerator that generates
+  atom-pair fingerprints
+
+
+  /param minDistance            minimum distance between atoms to be considered
+  in a pair, default is 1 bond
+  /param maxDistance            maximum distance between atoms to be considered
+  in a pair, default is maxPathLen-1 bonds
+  /param includeChirality       if set, chirality will be used in the atom
+  invariants, this is ignored if atomInvariantsGenerator is provided
+  /param use2D                  if set, the 2D (topological) distance matrix
+  will be used
+  /param useCountSimulation         if set, use count simulation while
+  generating the fingerprint
+  /param atomInvariantsGenerator    atom invariants to be used during
+  fingerprint generation
+  /param bondInvariantsGenerator    bond invariants to be used during
+  fingerprint generation
+
+  /return FingerprintGenerator that generates atom-pair fingerprints
+ */
 FingerprintGenerator getAtomPairGenerator(
     const unsigned int minDistance = 1,
     const unsigned int maxDistance = maxPathLen - 1,
     const bool includeChirality = false, const bool use2D = true,
     const bool useCountSimulation = true,
-    AtomInvariantsGenerator *atomInvariantsGenerator = 0,
-    BondInvariantsGenerator *bondInvariantsGenerator = 0);
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+    BondInvariantsGenerator *bondInvariantsGenerator = nullptr);
 }  // namespace AtomPair
 }  // namespace RDKit
 

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -108,8 +108,6 @@ class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
       const std::vector<std::uint32_t> *atomInvariants = nullptr,
       const std::vector<std::uint32_t> *bondInvariants = nullptr) const;
 
-  void cleanUpEnvironments(
-      std::vector<AtomEnvironment *> atomEnvironments) const;
 };
 
 /*!

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -2,6 +2,7 @@
 #define RD_ATOMPAIRGEN_H_2018_06
 
 #include <GraphMol/Fingerprints/FingerprintGenerator.h>
+#include <cstdint>
 
 namespace RDKit {
 namespace AtomPair {
@@ -31,7 +32,7 @@ class AtomPairArguments : public FingerprintArguments {
   const unsigned int d_minDistance;
   const unsigned int d_maxDistance;
 
-  boost::uint64_t getResultSize() const;
+  std::uint64_t getResultSize() const;
 
   /*!
     /brief construct a new AtomPairArguments object
@@ -59,29 +60,31 @@ class AtomPairArguments : public FingerprintArguments {
 
  */
 class AtomPairAtomEnv : public AtomEnvironment {
-  const std::vector<boost::uint32_t> *atomCodeCache;
   const unsigned int d_atomIdFirst;
   const unsigned int d_atomIdSecond;
   const unsigned int d_distance;
+  const std::uint32_t d_atomCodeFirst;
+  const std::uint32_t d_atomCodeSecond;
 
  public:
-  boost::uint32_t getBitId(
+  std::uint32_t getBitId(
       FingerprintArguments *arguments,
-      const std::vector<boost::uint32_t> *atomInvariants,
-      const std::vector<boost::uint32_t> *bondInvariants) const;
-
-  const std::vector<boost::uint32_t> *getAtomCodeCache() const;
+      const std::vector<std::uint32_t> *atomInvariants,
+      const std::vector<std::uint32_t> *bondInvariants) const;
 
   /*!
     /brief construct a new AtomPairAtomEnv object
 
-    /param atomIdFirst  id of the first atom of the atom-pair
-    /param atomIdSecond id of the second atom of the atom-pair
-    /param distance     distance between the atoms
+    /param atomIdFirst      id of the first atom of the atom-pair
+    /param atomIdSecond     id of the second atom of the atom-pair
+    /param distance         distance between the atoms
+    /param atomCodeFirst    hashed atom code for the first atom
+    /param atomCodeSecond   hashed atom code for the second atom
    */
-  AtomPairAtomEnv(const std::vector<boost::uint32_t> *atomCodeCache,
-                  const unsigned int atomIdFirst,
-                  const unsigned int atomIdSecond, const unsigned int distance);
+  AtomPairAtomEnv(const unsigned int atomIdFirst,
+                  const unsigned int atomIdSecond, const unsigned int distance,
+                  const std::uint32_t atomCodeFirst,
+                  const std::uint32_t atomCodeSecond);
 };
 
 /*!
@@ -92,11 +95,11 @@ class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
  public:
   std::vector<AtomEnvironment *> getEnvironments(
       const ROMol &mol, FingerprintArguments *arguments,
-      const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+      const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const int confId = -1, const AdditionalOutput *additionalOutput = nullptr,
-      const std::vector<boost::uint32_t> *atomInvariants = nullptr,
-      const std::vector<boost::uint32_t> *bondInvariants = nullptr) const;
+      const std::vector<std::uint32_t> *atomInvariants = nullptr,
+      const std::vector<std::uint32_t> *bondInvariants = nullptr) const;
 
   void cleanUpEnvironments(
       std::vector<AtomEnvironment *> atomEnvironments) const;

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -133,7 +133,7 @@ class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
 
   /return FingerprintGenerator that generates atom-pair fingerprints
  */
-FingerprintGenerator getAtomPairGenerator(
+FingerprintGenerator *getAtomPairGenerator(
     const unsigned int minDistance = 1,
     const unsigned int maxDistance = maxPathLen - 1,
     const bool includeChirality = false, const bool use2D = true,

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -94,6 +94,13 @@ class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
       std::vector<AtomEnvironment *> atomEnvironments) const;
 };
 
+FingerprintGenerator getAtomPairGenerator(
+    const unsigned int minDistance = 1,
+    const unsigned int maxDistance = maxPathLen - 1,
+    const bool includeChirality = false, const bool use2D = true,
+    const bool useCountSimulation = true,
+    AtomInvariantsGenerator *atomInvariantsGenerator = 0,
+    BondInvariantsGenerator *bondInvariantsGenerator = 0);
 }  // namespace AtomPair
 }  // namespace RDKit
 

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -76,7 +76,8 @@ class AtomPairAtomEnv : public AtomEnvironment {
   std::uint32_t getBitId(
       FingerprintArguments *arguments,
       const std::vector<std::uint32_t> *atomInvariants,
-      const std::vector<std::uint32_t> *bondInvariants) const;
+      const std::vector<std::uint32_t> *bondInvariants,
+      const AdditionalOutput *additionalOutput) const;
 
   /*!
     /brief construct a new AtomPairAtomEnv object

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -21,6 +21,12 @@ const unsigned int numPathBits = 5;
 const unsigned int maxPathLen = (1 << numPathBits) - 1;
 const unsigned int numAtomPairFingerprintBits = numPathBits + 2 * codeSize;
 
+unsigned int numPiElectrons(const Atom *atom);
+std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract = 0,
+                          bool includeChirality = false);
+std::uint32_t getAtomPairCode(std::uint32_t codeI, std::uint32_t codeJ,
+                              unsigned int dist, bool includeChirality = false);
+
 /*!
   /brief class that holds atom-pair fingerprint specific arguments
 

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -1,0 +1,73 @@
+#ifndef RD_ATOMPAIRGEN_H_2018_06
+#define RD_ATOMPAIRGEN_H_2018_06
+
+#include <GraphMol/Fingerprints/FingerprintGenerator.h>
+
+namespace RDKit {
+namespace AtomPair {
+
+const unsigned int numTypeBits = 4;
+const unsigned int atomNumberTypes[1 << numTypeBits] = {
+    5, 6, 7, 8, 9, 14, 15, 16, 17, 33, 34, 35, 51, 52, 43};
+const unsigned int numPiBits = 2;
+const unsigned int maxNumPi = (1 << numPiBits) - 1;
+const unsigned int numBranchBits = 3;
+const unsigned int maxNumBranches = (1 << numBranchBits) - 1;
+const unsigned int numChiralBits = 2;
+const unsigned int codeSize = numTypeBits + numPiBits + numBranchBits;
+const unsigned int numPathBits = 5;
+const unsigned int maxPathLen = (1 << numPathBits) - 1;
+const unsigned int numAtomPairFingerprintBits = numPathBits + 2 * codeSize;
+
+class AtomPairArguments : public FingerprintArguments {
+ public:
+  const bool includeChirality;
+  const bool use2D;
+  const unsigned int minDistance;
+  const unsigned int maxDistance;
+
+  unsigned int getResultSize() const;
+
+  AtomPairArguments(const bool countSimulation, const bool includeChirality,
+                    const bool use2D, const unsigned int minDistance,
+                    const unsigned int maxDistance);
+};
+
+class AtomPairAtomEnv : public AtomEnvironment<AtomPairArguments> {
+  const std::vector<boost::uint32_t> *atomCodeCache;
+  const unsigned int atomIdFirst;
+  const unsigned int atomIdSecond;
+  const unsigned int distance;
+
+ public:
+  boost::uint32_t getBitId(
+      AtomPairArguments arguments,
+      const std::vector<boost::uint32_t> *atomInvariants,
+      const std::vector<boost::uint32_t> *bondInvariants) const;
+
+  const std::vector<boost::uint32_t> *getAtomCodeCache() const;
+
+  AtomPairAtomEnv(const std::vector<boost::uint32_t> *atomCodeCache,
+                  const unsigned int atomIdFirst,
+                  const unsigned int atomIdSecond, const unsigned int distance);
+};
+
+class AtomPairEnvGenerator
+    : public AtomEnvironmentGenerator<AtomPairAtomEnv, AtomPairArguments> {
+ public:
+  std::vector<AtomPairAtomEnv> getEnvironments(
+      const ROMol &mol, const AtomPairArguments arguments,
+      const std::vector<boost::uint32_t> *fromAtoms = 0,
+      const std::vector<boost::uint32_t> *ignoreAtoms = 0,
+      const int confId = -1, const AdditionalOutput *additionalOutput = 0,
+      const std::vector<boost::uint32_t> *atomInvariants = 0,
+      const std::vector<boost::uint32_t> *bondInvariants = 0) const;
+
+  void cleanUpEnvironments(
+      const std::vector<AtomPairAtomEnv> &atomEnvironments) const;
+};
+
+}  // namespace AtomPair
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -22,10 +22,10 @@ const unsigned int maxPathLen = (1 << numPathBits) - 1;
 const unsigned int numAtomPairFingerprintBits = numPathBits + 2 * codeSize;
 
 unsigned int numPiElectrons(const Atom *atom);
-std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract = 0,
-                          bool includeChirality = false);
+std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract,
+                          bool includeChirality);
 std::uint32_t getAtomPairCode(std::uint32_t codeI, std::uint32_t codeJ,
-                              unsigned int dist, bool includeChirality = false);
+                              unsigned int dist, bool includeChirality);
 
 /*!
   /brief class that holds atom-pair fingerprint specific arguments
@@ -55,8 +55,9 @@ class AtomPairArguments : public FingerprintArguments {
     /param maxDistance      maximum distance between atoms to be considered in a
     pair, default is maxPathLen-1 bonds
    */
-  AtomPairArguments(const bool countSimulation, const bool includeChirality,
-                    const bool use2D, const unsigned int minDistance = 1,
+  AtomPairArguments(const bool countSimulation = true,
+                    const bool includeChirality = false,
+                    const bool use2D = true, const unsigned int minDistance = 1,
                     const unsigned int maxDistance = (maxPathLen - 1));
 };
 
@@ -73,11 +74,10 @@ class AtomPairAtomEnv : public AtomEnvironment {
   const std::uint32_t d_atomCodeSecond;
 
  public:
-  std::uint32_t getBitId(
-      FingerprintArguments *arguments,
-      const std::vector<std::uint32_t> *atomInvariants,
-      const std::vector<std::uint32_t> *bondInvariants,
-      const AdditionalOutput *additionalOutput) const;
+  std::uint32_t getBitId(FingerprintArguments *arguments,
+                         const std::vector<std::uint32_t> *atomInvariants,
+                         const std::vector<std::uint32_t> *bondInvariants,
+                         const AdditionalOutput *additionalOutput) const;
 
   /*!
     /brief construct a new AtomPairAtomEnv object
@@ -102,12 +102,11 @@ class AtomPairEnvGenerator : public AtomEnvironmentGenerator {
  public:
   std::vector<AtomEnvironment *> getEnvironments(
       const ROMol &mol, FingerprintArguments *arguments,
-      const std::vector<std::uint32_t> *fromAtoms = nullptr,
-      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
-      const int confId = -1, const AdditionalOutput *additionalOutput = nullptr,
-      const std::vector<std::uint32_t> *atomInvariants = nullptr,
-      const std::vector<std::uint32_t> *bondInvariants = nullptr) const;
-
+      const std::vector<std::uint32_t> *fromAtoms,
+      const std::vector<std::uint32_t> *ignoreAtoms, const int confId,
+      const AdditionalOutput *additionalOutput,
+      const std::vector<std::uint32_t> *atomInvariants,
+      const std::vector<std::uint32_t> *bondInvariants) const;
 };
 
 /*!

--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -2,7 +2,7 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_FINGERPRINTS_BUILD)
 rdkit_library(Fingerprints
-              Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp AtomPairs.cpp MACCS.cpp
+              Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp AtomPairs.cpp MACCS.cpp FingerprintGenerator.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse GraphMol
                 ${RDKit_THREAD_LIBS} )
 
@@ -10,6 +10,7 @@ rdkit_headers(AtomPairs.h
               Fingerprints.h
               MorganFingerprints.h
               MACCS.h
+              FingerprintGenerator.h
               DEST GraphMol/Fingerprints)
 
 rdkit_test(testFingerprints test1.cpp LINK_LIBRARIES 

--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -2,7 +2,7 @@
 remove_definitions(-DRDKIT_GRAPHMOL_BUILD)
 add_definitions(-DRDKIT_FINGERPRINTS_BUILD)
 rdkit_library(Fingerprints
-              Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp AtomPairs.cpp MACCS.cpp FingerprintGenerator.cpp
+              Fingerprints.cpp PatternFingerprints.cpp MorganFingerprints.cpp AtomPairs.cpp MACCS.cpp FingerprintGenerator.cpp AtomPairGenerator.cpp
               LINK_LIBRARIES Subgraphs SubstructMatch SmilesParse GraphMol
                 ${RDKit_THREAD_LIBS} )
 
@@ -11,6 +11,7 @@ rdkit_headers(AtomPairs.h
               MorganFingerprints.h
               MACCS.h
               FingerprintGenerator.h
+              AtomPairGenerator.h
               DEST GraphMol/Fingerprints)
 
 rdkit_test(testFingerprints test1.cpp LINK_LIBRARIES 

--- a/Code/GraphMol/Fingerprints/CMakeLists.txt
+++ b/Code/GraphMol/Fingerprints/CMakeLists.txt
@@ -19,4 +19,7 @@ rdkit_test(testFingerprints test1.cpp LINK_LIBRARIES
            Subgraphs GraphMol DataStructs RDGeometryLib
            RDGeneral  ${RDKit_THREAD_LIBS}  )
 
+rdkit_test(testFingerprintGenerators testFingerprintGenerators.cpp LINK_LIBRARIES 
+           Fingerprints SmilesParse GraphMol DataStructs
+           RDGeneral )
 

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -3,6 +3,7 @@
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/SparseBitVect.h>
 #include <GraphMol/Fingerprints/FingerprintGenerator.h>
+#include <cstdint>
 
 namespace RDKit {
 
@@ -33,35 +34,37 @@ void FingerprintGenerator::cleanUpResources() {
   dp_fingerprintArguments = nullptr;
 }
 
-SparseIntVect<boost::uint32_t> *FingerprintGenerator::getFingerprint(
-    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-    const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
+SparseIntVect<std::uint32_t> *FingerprintGenerator::getFingerprint(
+    const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms,
+    const std::vector<std::uint32_t> *ignoreAtoms, const int confId,
     const AdditionalOutput *additionalOutput) const {
-  SparseIntVect<boost::uint32_t> *res = new SparseIntVect<boost::uint32_t>(
+  SparseIntVect<std::uint32_t> *res = new SparseIntVect<std::uint32_t>(
       dp_fingerprintArguments->getResultSize());
 
   std::vector<AtomEnvironment *> atomEnvironments =
-      dp_atomEnvironmentGenerator->getEnvironments(
-          mol, dp_fingerprintArguments, fromAtoms, ignoreAtoms, confId,
-          additionalOutput);
+      dp_atomEnvironmentGenerator->getEnvironments(mol, dp_fingerprintArguments,
+                                                   fromAtoms, ignoreAtoms,
+                                                   confId, additionalOutput);
 
-  std::vector<boost::uint32_t> *atomInvariantsAsPointer = nullptr;
-  std::vector<boost::uint32_t> atomInvariants;
+  std::vector<std::uint32_t> *atomInvariantsAsPointer = nullptr;
+  std::vector<std::uint32_t> atomInvariants;
   if (dp_atomInvariantsGenerator) {
-    atomInvariants = dp_atomInvariantsGenerator->getAtomInvariants(mol, dp_fingerprintArguments);
+    atomInvariants = dp_atomInvariantsGenerator->getAtomInvariants(
+        mol, dp_fingerprintArguments);
     atomInvariantsAsPointer = &atomInvariants;
   }
 
-  std::vector<boost::uint32_t> *bondInvariantsAsPointer = nullptr;
-  std::vector<boost::uint32_t> bondInvariants;
+  std::vector<std::uint32_t> *bondInvariantsAsPointer = nullptr;
+  std::vector<std::uint32_t> bondInvariants;
   if (dp_bondInvariantsGenerator) {
-    bondInvariants = dp_bondInvariantsGenerator->getBondInvariants(mol, dp_fingerprintArguments);
+    bondInvariants = dp_bondInvariantsGenerator->getBondInvariants(
+        mol, dp_fingerprintArguments);
     bondInvariantsAsPointer = &bondInvariants;
   }
 
   for (std::vector<AtomEnvironment *>::iterator it = atomEnvironments.begin();
        it != atomEnvironments.end(); it++) {
-    boost::uint32_t bitId =
+    std::uint32_t bitId =
         (*it)->getBitId(dp_fingerprintArguments, atomInvariantsAsPointer,
                         bondInvariantsAsPointer);
 
@@ -72,33 +75,26 @@ SparseIntVect<boost::uint32_t> *FingerprintGenerator::getFingerprint(
     }
   }
 
-  dp_atomEnvironmentGenerator->cleanUpEnvironments(atomEnvironments);
-
-  for (std::vector<AtomEnvironment *>::iterator it = atomEnvironments.begin();
-       it != atomEnvironments.end(); it++) {
-    delete (*it);
-  }
-
   return res;
 }
 
 SparseBitVect *FingerprintGenerator::getFingerprintAsBitVect(
-    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-    const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
+    const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms,
+    const std::vector<std::uint32_t> *ignoreAtoms, const int confId,
     const AdditionalOutput *additionalOutput) const {
   return 0;
 }
 
-SparseIntVect<boost::uint32_t> *FingerprintGenerator::getFoldedFingerprint(
-    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-    const std::vector<boost::uint32_t> *ignoreAtoms,
+SparseIntVect<std::uint32_t> *FingerprintGenerator::getFoldedFingerprint(
+    const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms,
+    const std::vector<std::uint32_t> *ignoreAtoms,
     const AdditionalOutput *additionalOutput) const {
   return 0;
 }
 
 ExplicitBitVect *FingerprintGenerator::getFoldedFingerprintAsBitVect(
-    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-    const std::vector<boost::uint32_t> *ignoreAtoms,
+    const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms,
+    const std::vector<std::uint32_t> *ignoreAtoms,
     const AdditionalOutput *additionalOutput) const {
   return 0;
 }

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -1,0 +1,54 @@
+
+#include <DataStructs/SparseIntVect.h>
+#include <DataStructs/ExplicitBitVect.h>
+#include <DataStructs/SparseBitVect.h>
+#include "FingerprintGenerator.h"
+
+namespace RDKit {
+
+template <class T1, class T2>
+FingerprintGenerator<T1, T2>::FingerprintGenerator(
+    T1 atomEnvironmentGenerator, T2 fingerprintArguments,
+    AtomInvariants *atomInvariants, BondInvariants *bondInvariants) {
+  this->atomEnvironmentGenerator = atomEnvironmentGenerator;
+  this->fingerprintArguments = fingerprintArguments;
+  this->asCommonArguments = &this->fingerprintArguments;
+  this->atomInvariants = atomInvariants;
+  this->bondInvariants = bondInvariants;
+}
+
+template <class T1, class T2>
+SparseIntVect<boost::uint32_t> *FingerprintGenerator<T1, T2>::getFingerprint(
+    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
+    const std::vector<boost::uint32_t> *ignoreAtoms,
+    const int confId,  // for atom pair fp
+    const AdditionalOutput *additionalOutput) const {
+  return 0;
+}
+
+template <class T1, class T2>
+SparseBitVect *FingerprintGenerator<T1, T2>::getFingerprintAsBitVect(
+    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
+    const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
+    const AdditionalOutput *additionalOutput) const {
+  return 0;
+}
+
+template <class T1, class T2>
+SparseIntVect<boost::uint32_t>
+    *FingerprintGenerator<T1, T2>::getFoldedFingerprint(
+        const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
+        const std::vector<boost::uint32_t> *ignoreAtoms,
+        const AdditionalOutput *additionalOutput) const {
+  return 0;
+}
+
+template <class T1, class T2>
+ExplicitBitVect *FingerprintGenerator<T1, T2>::getFoldedFingerprintAsBitVect(
+    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
+    const std::vector<boost::uint32_t> *ignoreAtoms,
+    const AdditionalOutput *additionalOutput) const {
+  return 0;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -6,8 +6,8 @@
 
 namespace RDKit {
 
-template <class T1, class T2>
-FingerprintGenerator<T1, T2>::FingerprintGenerator(
+template <class T1, class T2, class T3>
+FingerprintGenerator<T1, T2, T3>::FingerprintGenerator(
     T1 atomEnvironmentGenerator, T2 fingerprintArguments,
     AtomInvariants *atomInvariants, BondInvariants *bondInvariants) {
   this->atomEnvironmentGenerator = atomEnvironmentGenerator;
@@ -17,34 +17,65 @@ FingerprintGenerator<T1, T2>::FingerprintGenerator(
   this->bondInvariants = bondInvariants;
 }
 
-template <class T1, class T2>
-SparseIntVect<boost::uint32_t> *FingerprintGenerator<T1, T2>::getFingerprint(
-    const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-    const std::vector<boost::uint32_t> *ignoreAtoms,
-    const int confId,  // for atom pair fp
-    const AdditionalOutput *additionalOutput) const {
-  return 0;
+template <class T1, class T2, class T3>
+SparseIntVect<boost::uint32_t>
+    *FingerprintGenerator<T1, T2, T3>::getFingerprint(
+        const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
+        const std::vector<boost::uint32_t> *ignoreAtoms,
+        const int confId,  // for atom pair fp
+        const AdditionalOutput *additionalOutput) const {
+  SparseIntVect<boost::uint32_t> *res = new SparseIntVect<boost::uint32_t>(
+      this->asCommonArguments->getResultSize());
+
+  std::vector<T3> atomEnvironments =
+      this->atomEnvironmentGenerator.getEnvironments(
+          mol, this->fingerprintArguments, fromAtoms, ignoreAtoms, confId,
+          additionalOutput);
+
+  std::vector<boost::uint32_t> *atomInvariants =
+      this->atomInvariants->getAtomInvariants(mol);
+  std::vector<boost::uint32_t> *bondInvariants =
+      this->atomInvariants->getBondInvariants(mol);
+
+  for (unsigned int i = 0; i != atomEnvironments.size(); i++) {
+    boost::uint32_t bitId = atomEnvironments[i].getBitId(
+        this->fingerprintArguments, atomInvariants, bondInvariants);
+
+    if (this->asCommonArguments->countSimulation) {
+      res->setVal(bitId, res->getVal(bitId) + 1);
+    } else {
+      res->setVal(bitId, 1);
+    }
+  }
+
+  delete atomInvariants;
+  delete bondInvariants;
+
+  this->atomEnvironmentGeerator.cleanUpEnvironments(atomEnvironments);
+
+  return res;
 }
 
-template <class T1, class T2>
-SparseBitVect *FingerprintGenerator<T1, T2>::getFingerprintAsBitVect(
+template <class T1, class T2, class T3>
+SparseBitVect *FingerprintGenerator<T1, T2, T3>::getFingerprintAsBitVect(
     const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
     const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
     const AdditionalOutput *additionalOutput) const {
   return 0;
 }
 
-template <class T1, class T2>
+template <class T1, class T2, class T3>
 SparseIntVect<boost::uint32_t>
-    *FingerprintGenerator<T1, T2>::getFoldedFingerprint(
+    *FingerprintGenerator<T1, T2, T3>::getFoldedFingerprint(
         const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
         const std::vector<boost::uint32_t> *ignoreAtoms,
         const AdditionalOutput *additionalOutput) const {
   return 0;
 }
 
-template <class T1, class T2>
-ExplicitBitVect *FingerprintGenerator<T1, T2>::getFoldedFingerprintAsBitVect(
+template <class T1, class T2, class T3>
+ExplicitBitVect *
+FingerprintGenerator<T1, T2, T3>::getFoldedFingerprintAsBitVect(
     const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
     const std::vector<boost::uint32_t> *ignoreAtoms,
     const AdditionalOutput *additionalOutput) const {

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -45,15 +45,25 @@ SparseIntVect<boost::uint32_t> *FingerprintGenerator::getFingerprint(
           mol, this->fingerprintArguments, fromAtoms, ignoreAtoms, confId,
           additionalOutput);
 
-  std::vector<boost::uint32_t> atomInvariants =
-      this->atomInvariantsGenerator->getAtomInvariants(mol);
-  std::vector<boost::uint32_t> bondInvariants =
-      this->bondInvariantsGenerator->getBondInvariants(mol);
+  std::vector<boost::uint32_t> *atomInvariantsAsPointer = 0;
+  std::vector<boost::uint32_t> atomInvariants;
+  if (this->atomInvariantsGenerator) {
+    atomInvariants = this->atomInvariantsGenerator->getAtomInvariants(mol);
+    atomInvariantsAsPointer = &atomInvariants;
+  }
+
+  std::vector<boost::uint32_t> *bondInvariantsAsPointer = 0;
+  std::vector<boost::uint32_t> bondInvariants;
+  if (this->atomInvariantsGenerator) {
+    bondInvariants = this->bondInvariantsGenerator->getBondInvariants(mol);
+    bondInvariantsAsPointer = &bondInvariants;
+  }
 
   for (std::vector<AtomEnvironment *>::iterator it = atomEnvironments.begin();
        it != atomEnvironments.end(); it++) {
-    boost::uint32_t bitId = (*it)->getBitId(this->fingerprintArguments,
-                                            &atomInvariants, &bondInvariants);
+    boost::uint32_t bitId =
+        (*it)->getBitId(this->fingerprintArguments, atomInvariantsAsPointer,
+                        bondInvariantsAsPointer);
 
     if (this->fingerprintArguments->countSimulation) {
       res->setVal(bitId, res->getVal(bitId) + 1);

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -66,7 +66,7 @@ SparseIntVect<std::uint32_t> *FingerprintGenerator::getFingerprint(
        it != atomEnvironments.end(); it++) {
     std::uint32_t bitId =
         (*it)->getBitId(dp_fingerprintArguments, atomInvariantsAsPointer,
-                        bondInvariantsAsPointer);
+                        bondInvariantsAsPointer, additionalOutput);
 
     if (dp_fingerprintArguments->d_countSimulation) {
       res->setVal(bitId, res->getVal(bitId) + 1);

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -27,7 +27,7 @@ FingerprintGenerator::FingerprintGenerator(
   this->dp_bondInvariantsGenerator = bondInvariantsGenerator;
 }
 
-void FingerprintGenerator::cleanUpResources() {
+FingerprintGenerator::~FingerprintGenerator() {
   delete dp_atomEnvironmentGenerator;
   delete dp_fingerprintArguments;
   dp_atomEnvironmentGenerator = nullptr;

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -2,27 +2,30 @@
 #include <DataStructs/SparseIntVect.h>
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/SparseBitVect.h>
-#include "FingerprintGenerator.h"
+#include <GraphMol/Fingerprints/FingerprintGenerator.h>
 
 namespace RDKit {
+
+FingerprintArguments::FingerprintArguments(const bool countSimulation)
+    : countSimulation(countSimulation) {}
 
 template <class T1, class T2, class T3>
 FingerprintGenerator<T1, T2, T3>::FingerprintGenerator(
     T1 atomEnvironmentGenerator, T2 fingerprintArguments,
-    AtomInvariants *atomInvariants, BondInvariants *bondInvariants) {
+    AtomInvariantsGenerator *atomInvariantsGenerator,
+    BondInvariantsGenerator *bondInvariantsGenerator) {
   this->atomEnvironmentGenerator = atomEnvironmentGenerator;
   this->fingerprintArguments = fingerprintArguments;
   this->asCommonArguments = &this->fingerprintArguments;
-  this->atomInvariants = atomInvariants;
-  this->bondInvariants = bondInvariants;
+  this->atomInvariantsGenerator = atomInvariantsGenerator;
+  this->bondInvariantsGenerator = bondInvariantsGenerator;
 }
 
 template <class T1, class T2, class T3>
 SparseIntVect<boost::uint32_t>
     *FingerprintGenerator<T1, T2, T3>::getFingerprint(
         const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms,
-        const std::vector<boost::uint32_t> *ignoreAtoms,
-        const int confId,  // for atom pair fp
+        const std::vector<boost::uint32_t> *ignoreAtoms, const int confId,
         const AdditionalOutput *additionalOutput) const {
   SparseIntVect<boost::uint32_t> *res = new SparseIntVect<boost::uint32_t>(
       this->asCommonArguments->getResultSize());

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -12,6 +12,8 @@ class ROMol;
 struct AdditionalOutput {
   // will review this structure once more fignerprint types are implemented
 
+  std::vector<std::vector<std::uint64_t>> *atomToBits;
+
   std::map<std::uint32_t, std::vector<std::pair<std::uint32_t, std::uint32_t>>>
       *bitInfoMap;
   // morgan fp
@@ -69,8 +71,9 @@ class AtomEnvironment {
    */
   virtual std::uint32_t getBitId(
       FingerprintArguments *arguments,
-      const std::vector<std::uint32_t> *atomInvariants = nullptr,
-      const std::vector<std::uint32_t> *bondInvariants = nullptr) const = 0;
+      const std::vector<std::uint32_t> *atomInvariants,
+      const std::vector<std::uint32_t> *bondInvariants,
+      const AdditionalOutput *AdditionalOutput) const = 0;
 
   virtual ~AtomEnvironment() = 0;
 };

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -178,7 +178,7 @@ class FingerprintGenerator {
       AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
       BondInvariantsGenerator *bondInvariantsGenerator = nullptr);
 
-  void cleanUpResources();
+  ~FingerprintGenerator();
 
   SparseIntVect<std::uint32_t> *getFingerprint(
       const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms = nullptr,

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -31,6 +31,7 @@ union AdditionalOutput {
 
 template <class T1, class T2>
 class AtomEnvironmentGenerator {
+ public:
   virtual std::vector<T1> getEnvironments(
       const ROMol &mol, const T2 arguments,
       const std::vector<boost::uint32_t> *fromAtoms = 0,
@@ -38,20 +39,26 @@ class AtomEnvironmentGenerator {
       const int confId = -1,
       const AdditionalOutput *additionalOutput = 0) const = 0;
 
+  virtual void cleanUpEnvironments(
+      const std::vector<T1> &atomEnvironments) const = 0;
+  // to remove dynamically allocated resources that are shared
+  // between atom environments if there are any
 };
 
 template <class T>
 class AtomEnvironment {
-  virtual boost::uint32_t getBitId(T arguments) const = 0;
-
+ public:
+  virtual boost::uint32_t getBitId(
+      const T arguments, const std::vector<boost::uint32_t> *atomInvariants = 0,
+      const std::vector<boost::uint32_t> *bondInvariants = 0) const = 0;
 };
 
 class FingerprintArguments {
+ public:
   bool countSimulation;
 
+  virtual unsigned int getResultSize() const = 0;
 };
-
-
 
 class AtomInvariants {
   // arguments
@@ -67,7 +74,7 @@ class BondInvariants {
   std::vector<boost::uint32_t> getBondInvariants(const ROMol &mol);
 };
 
-template <class T1, class T2>
+template <class T1, class T2, class T3>
 class FingerprintGenerator {
   T1 atomEnvironmentGenerator;
   AtomInvariants *atomInvariants;
@@ -77,10 +84,9 @@ class FingerprintGenerator {
   // more data to hold arguments and fp type
 
  public:
-  FingerprintGenerator(
-      T1 atomEnvironmentGenerator,
-      T2 fingerprintArguments, AtomInvariants *atomInvariant = 0,
-      BondInvariants *bondInvariants = 0);
+  FingerprintGenerator(T1 atomEnvironmentGenerator, T2 fingerprintArguments,
+                       AtomInvariants *atomInvariant = 0,
+                       BondInvariants *bondInvariants = 0);
 
   SparseIntVect<boost::uint32_t> *getFingerprint(
       const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = 0,

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -4,21 +4,21 @@
 #include <DataStructs/SparseIntVect.h>
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/SparseBitVect.h>
+#include <cstdint>
 
 namespace RDKit {
 class ROMol;
 
-union AdditionalOutput {
-  // will hold differently stuctured additonal output
+struct AdditionalOutput {
+  // will review this structure once more fignerprint types are implemented
 
-  std::map<boost::uint32_t,
-           std::vector<std::pair<boost::uint32_t, boost::uint32_t>>>
+  std::map<std::uint32_t, std::vector<std::pair<std::uint32_t, std::uint32_t>>>
       *bitInfoMap;
   // morgan fp
   // maps bitId -> vector of (atomId, radius)
 
-  std::pair<std::vector<std::vector<boost::uint32_t>>,
-            std::map<boost::uint32_t, std::vector<std::vector<int>>>> *bitInfo;
+  std::pair<std::vector<std::vector<std::uint32_t>>,
+            std::map<std::uint32_t, std::vector<std::vector<int>>>> *bitInfo;
   // rdkit fp
   // first part, vector of bits set for each atom, must have the same size as
   // atom count for molecule
@@ -30,9 +30,9 @@ union AdditionalOutput {
 };
 
 /*!
-  /brief Abstract base class that holds arguments that are common amongst all
-  fingerprint types and classes inherited from this would hold fingerprint type
-  specific arguments
+  /brief Abstract base class that holds molecule independent arguments that are
+  common amongst all fingerprint types and classes inherited from this would
+  hold fingerprint type specific arguments
 
  */
 class FingerprintArguments {
@@ -43,9 +43,9 @@ class FingerprintArguments {
   /*!
     /brief Returns the size of the fingerprint based on arguments
 
-    /return boost::uint64_t size of the fingerprint
+    /return std::uint64_t size of the fingerprint
    */
-  virtual boost::uint64_t getResultSize() const = 0;
+  virtual std::uint64_t getResultSize() const = 0;
 
   virtual ~FingerprintArguments() = 0;
 };
@@ -60,16 +60,17 @@ class AtomEnvironment {
   /*!
     /brief calculates and returns the bit id to be set for this atom-environment
 
-    /param arguments         Fingerprinting type specific arguments
+    /param arguments         Fingerprinting type specific molecule independent
+    arguments
     /param atomInvariants    Atom-invariants to be used during hashing
     /param bondInvariants    Bond-invariants to be used during hashing
 
-    /return boost::uint32_t  calculated bit id for this environment
+    /return std::uint32_t  calculated bit id for this environment
    */
-  virtual boost::uint32_t getBitId(
+  virtual std::uint32_t getBitId(
       FingerprintArguments *arguments,
-      const std::vector<boost::uint32_t> *atomInvariants = nullptr,
-      const std::vector<boost::uint32_t> *bondInvariants = nullptr) const = 0;
+      const std::vector<std::uint32_t> *atomInvariants = nullptr,
+      const std::vector<std::uint32_t> *bondInvariants = nullptr) const = 0;
 
   virtual ~AtomEnvironment() = 0;
 };
@@ -84,7 +85,8 @@ class AtomEnvironmentGenerator {
     /brief generate and return all atom-envorinments from a molecule
 
     /param mol               molecule to generate the atom-environments from
-    /param arguments         fingerprint type specific arguments
+    /param arguments         fingerprint type specific molecule independent
+    arguments
     /param fromAtoms         atoms to be used during environment generation,
     usage of this parameter depends on the implementation of different
     fingerprint types
@@ -107,14 +109,11 @@ class AtomEnvironmentGenerator {
    */
   virtual std::vector<AtomEnvironment *> getEnvironments(
       const ROMol &mol, FingerprintArguments *arguments,
-      const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+      const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const int confId = -1, const AdditionalOutput *additionalOutput = nullptr,
-      const std::vector<boost::uint32_t> *atomInvariants = nullptr,
-      const std::vector<boost::uint32_t> *bondInvariants = nullptr) const = 0;
-
-  virtual void cleanUpEnvironments(
-      std::vector<AtomEnvironment *> atomEnvironments) const = 0;
+      const std::vector<std::uint32_t> *atomInvariants = nullptr,
+      const std::vector<std::uint32_t> *bondInvariants = nullptr) const = 0;
 
   virtual ~AtomEnvironmentGenerator() = 0;
 };
@@ -129,12 +128,13 @@ class AtomInvariantsGenerator {
     /brief get atom invariants from a molecule
 
     /param mol                   molecule to generate the atom invariants for
-    /param fingerprintArguments  fingerprinting type specific arguments
+    /param fingerprintArguments  fingerprinting type specific molecule
+    independent arguments
 
-    /return std::vector<boost::uint32_t> atom invariants generated for the given
+    /return std::vector<std::uint32_t> atom invariants generated for the given
     molecule
    */
-  virtual std::vector<boost::uint32_t> getAtomInvariants(
+  virtual std::vector<std::uint32_t> getAtomInvariants(
       const ROMol &mol,
       const FingerprintArguments *fingerprintArguments) const = 0;
 };
@@ -149,19 +149,21 @@ class BondInvariantsGenerator {
     /brief get bond invariants from a molecule
 
     /param mol                   molecule to generate the bond invariants for
-    /param fingerprintArguments  fingerprinting type specific arguments
+    /param fingerprintArguments  fingerprinting type specific molecule
+    independent arguments
 
-    /return std::vector<boost::uint32_t> bond invariants generated for the given
+    /return std::vector<std::uint32_t> bond invariants generated for the given
     molecule
    */
-  virtual std::vector<boost::uint32_t> getBondInvariants(
+  virtual std::vector<std::uint32_t> getBondInvariants(
       const ROMol &mol,
       const FingerprintArguments *fingerprintArguments) const = 0;
 };
 
 /*!
-  /brief class that generates same fingerprint style for different output formats
-  
+  /brief class that generates same fingerprint style for different output
+  formats
+
  */
 class FingerprintGenerator {
   FingerprintArguments *dp_fingerprintArguments;
@@ -176,29 +178,28 @@ class FingerprintGenerator {
       AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
       BondInvariantsGenerator *bondInvariantsGenerator = nullptr);
 
-
   void cleanUpResources();
 
-  SparseIntVect<boost::uint32_t> *getFingerprint(
-      const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+  SparseIntVect<std::uint32_t> *getFingerprint(
+      const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const int confId = -1,
       const AdditionalOutput *additionalOutput = nullptr) const;
 
   SparseBitVect *getFingerprintAsBitVect(
-      const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+      const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const int confId = -1,
       const AdditionalOutput *additionalOutput = nullptr) const;
 
-  SparseIntVect<boost::uint32_t> *getFoldedFingerprint(
-      const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+  SparseIntVect<std::uint32_t> *getFoldedFingerprint(
+      const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const AdditionalOutput *additionalOutput = nullptr) const;
 
   ExplicitBitVect *getFoldedFingerprintAsBitVect(
-      const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = nullptr,
-      const std::vector<boost::uint32_t> *ignoreAtoms = nullptr,
+      const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms = nullptr,
+      const std::vector<std::uint32_t> *ignoreAtoms = nullptr,
       const AdditionalOutput *additionalOutput = nullptr) const;
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -29,69 +29,117 @@ union AdditionalOutput {
   // atom count for molecule
 };
 
+/*
+ Class that holds the arguments for fingerprint generation
+ countSimulation: whether or not to return count simulated fingerprint
+*/
+class FingerprintArguments {
+ protected:
+  FingerprintArguments(const bool countSimulation);
+
+ public:
+  const bool countSimulation;
+
+  /*
+    Returns the size of the fingerprint based on arguments
+  */
+  virtual unsigned int getResultSize() const = 0;
+};
+
+/*
+    Class for generating atom environments from the molecule and clean up
+   resources after atom environments are no longer needed
+*/
 template <class T1, class T2>
 class AtomEnvironmentGenerator {
  public:
+  /*
+  Returns atom environments for a given molecule
+  mol: molecule to generate environments from
+  arguments: fingerprinting type specific arguments
+  fromAtoms: indicies of atoms to be used during fingerprint generation, usage
+  depends on fingerprint style
+  ignoreAtoms: indicies of atoms to be ignored during fingerprint generation,
+  usage depends on fingerprint style
+  confId: 3D configuration to use during fingerprint generation
+  additionalOutput: used to store additional outputs
+  atomInvariants: a list of invariants to use for the atom hashes
+  bondInvariants: a list of invariants to use for the bond hashes
+  */
   virtual std::vector<T1> getEnvironments(
       const ROMol &mol, const T2 arguments,
       const std::vector<boost::uint32_t> *fromAtoms = 0,
       const std::vector<boost::uint32_t> *ignoreAtoms = 0,
-      const int confId = -1,
-      const AdditionalOutput *additionalOutput = 0) const = 0;
+      const int confId = -1, const AdditionalOutput *additionalOutput = 0,
+      const std::vector<boost::uint32_t> *atomInvariants = 0,
+      const std::vector<boost::uint32_t> *bondInvariants = 0) const = 0;
 
+  /*
+  Does clean up for shared resources created for atom environments to use
+  atomEnvironments: vector of atom environments that hold the resources to be
+  cleaned
+  */
   virtual void cleanUpEnvironments(
       const std::vector<T1> &atomEnvironments) const = 0;
-  // to remove dynamically allocated resources that are shared
-  // between atom environments if there are any
 };
 
+/*
+Class to hold atom environments and hash them into bit ids
+*/
 template <class T>
 class AtomEnvironment {
  public:
+  /*
+  returns hashed bit id from this atom environment
+  arguments: fingerprint style specific arguments
+  atomInvariants: a list of invariants to use for the atom hashes
+  bondInvariants: a list of invariants to use for the bond hashes
+  */
   virtual boost::uint32_t getBitId(
       const T arguments, const std::vector<boost::uint32_t> *atomInvariants = 0,
       const std::vector<boost::uint32_t> *bondInvariants = 0) const = 0;
 };
 
-class FingerprintArguments {
- public:
-  bool countSimulation;
-
-  virtual unsigned int getResultSize() const = 0;
-};
-
-class AtomInvariants {
+class AtomInvariantsGenerator {
   // arguments
 
  public:
   std::vector<boost::uint32_t> getAtomInvariants(const ROMol &mol);
 };
 
-class BondInvariants {
+class BondInvariantsGenerator {
   // arguments
 
  public:
   std::vector<boost::uint32_t> getBondInvariants(const ROMol &mol);
 };
 
+/*
+Class to generate same fingerprint style for different output formats
+atomEnvironmentGenerator: environment generator class to use for fingerprinting
+atomInvariantsGenerator: atom invariants generator
+bondInvariantsGenerator: bond invariants generator
+asCommonArguments: fingerprintArguments as FingerprintArguments, used to access
+fingerprint style independent arguments
+fingerprintArguments: holds fingerprint style specific arguments
+*/
 template <class T1, class T2, class T3>
 class FingerprintGenerator {
   T1 atomEnvironmentGenerator;
-  AtomInvariants *atomInvariants;
-  BondInvariants *bondInvariants;
+  AtomInvariantsGenerator *atomInvariantsGenerator;
+  BondInvariantsGenerator *bondInvariantsGenerator;
   FingerprintArguments *asCommonArguments;
   T2 fingerprintArguments;
-  // more data to hold arguments and fp type
 
  public:
   FingerprintGenerator(T1 atomEnvironmentGenerator, T2 fingerprintArguments,
-                       AtomInvariants *atomInvariant = 0,
-                       BondInvariants *bondInvariants = 0);
+                       AtomInvariantsGenerator *atomInvariantsGenerator = 0,
+                       BondInvariantsGenerator *bondInvariantsGenerator = 0);
 
   SparseIntVect<boost::uint32_t> *getFingerprint(
       const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = 0,
       const std::vector<boost::uint32_t> *ignoreAtoms = 0,
-      const int confId = -1,  // for atom pair fp
+      const int confId = -1,
       const AdditionalOutput *additionalOutput = 0) const;
 
   SparseBitVect *getFingerprintAsBitVect(

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -8,8 +8,6 @@
 namespace RDKit {
 class ROMol;
 
-class AtomEnvironmentGenerator {};
-
 union AdditionalOutput {
   // will hold differently stuctured additonal output
 
@@ -29,7 +27,31 @@ union AdditionalOutput {
   std::vector<unsigned int> *atomCounts;
   // number of paths that set bits for each atom, must have the same size as
   // atom count for molecule
-}
+};
+
+template <class T1, class T2>
+class AtomEnvironmentGenerator {
+  virtual std::vector<T1> getEnvironments(
+      const ROMol &mol, const T2 arguments,
+      const std::vector<boost::uint32_t> *fromAtoms = 0,
+      const std::vector<boost::uint32_t> *ignoreAtoms = 0,
+      const int confId = -1,
+      const AdditionalOutput *additionalOutput = 0) const = 0;
+
+};
+
+template <class T>
+class AtomEnvironment {
+  virtual boost::uint32_t getBitId(T arguments) const = 0;
+
+};
+
+class FingerprintArguments {
+  bool countSimulation;
+
+};
+
+
 
 class AtomInvariants {
   // arguments
@@ -45,13 +67,21 @@ class BondInvariants {
   std::vector<boost::uint32_t> getBondInvariants(const ROMol &mol);
 };
 
+template <class T1, class T2>
 class FingerprintGenerator {
-  AtomEnvironmentGenerator atomEnvironmentGenerator;
-  AtomInvariants atomInvariant;
-  BondInvariants bondInvariant;
+  T1 atomEnvironmentGenerator;
+  AtomInvariants *atomInvariants;
+  BondInvariants *bondInvariants;
+  FingerprintArguments *asCommonArguments;
+  T2 fingerprintArguments;
   // more data to hold arguments and fp type
 
  public:
+  FingerprintGenerator(
+      T1 atomEnvironmentGenerator,
+      T2 fingerprintArguments, AtomInvariants *atomInvariant = 0,
+      BondInvariants *bondInvariants = 0);
+
   SparseIntVect<boost::uint32_t> *getFingerprint(
       const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = 0,
       const std::vector<boost::uint32_t> *ignoreAtoms = 0,
@@ -73,7 +103,7 @@ class FingerprintGenerator {
       const ROMol &mol, const std::vector<boost::uint32_t> *fromAtoms = 0,
       const std::vector<boost::uint32_t> *ignoreAtoms = 0,
       const AdditionalOutput *additionalOutput = 0) const;
-}
+};
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -19,7 +19,6 @@
 #include <GraphMol/Fingerprints/MorganFingerprints.h>
 #include <GraphMol/Fingerprints/MACCS.h>
 #include <GraphMol/Fingerprints/AtomPairs.h>
-#include <GraphMol/Fingerprints/AtomPairGenerator.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/BitOps.h>

--- a/Code/GraphMol/Fingerprints/test1.cpp
+++ b/Code/GraphMol/Fingerprints/test1.cpp
@@ -3508,59 +3508,6 @@ void testGitHubIssue1793() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
-void testAtomPairFPGenerator() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "Test compatibility between atom pair "
-                           "implementation for FingerprintGenerator"
-                           " and old atom pairs implementation"
-                        << std::endl;
-  {
-    ROMol *mol;
-    SparseIntVect<boost::int32_t> *fp1, *fp2;
-    SparseIntVect<boost::uint32_t> *fpu;
-
-    FingerprintGenerator atomPairGenerator = AtomPair::getAtomPairGenerator();
-
-    mol = SmilesToMol("CCC");
-    fp1 = AtomPairs::getAtomPairFingerprint(*mol);
-    fpu = atomPairGenerator.getFingerprint(*mol);
-    fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
-    std::map<boost::uint32_t, int> nz = fpu->getNonzeroElements();
-    for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
-         it != nz.end(); it++) {
-      fp2->setVal(static_cast<boost::int32_t>(it->first), it->second);
-    }
-
-    TEST_ASSERT(DiceSimilarity(*fp1, *fp2) == 1.0);
-    TEST_ASSERT(*fp1 == *fp2);
-
-    delete mol;
-    delete fp1;
-    delete fp2;
-    delete fpu;
-
-    mol = SmilesToMol("CC=O.Cl");
-    fp1 = AtomPairs::getAtomPairFingerprint(*mol);
-    fpu = atomPairGenerator.getFingerprint(*mol);
-    fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
-    nz = fpu->getNonzeroElements();
-    for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
-         it != nz.end(); it++) {
-      fp2->setVal(static_cast<boost::int32_t>(it->first), it->second);
-    }
-
-    TEST_ASSERT(DiceSimilarity(*fp1, *fp2) == 1.0);
-    TEST_ASSERT(*fp1 == *fp2);
-
-    delete mol;
-    delete fp1;
-    delete fp2;
-    delete fpu;
-
-    atomPairGenerator.cleanUpResources();
-  }
-}
-
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -3615,7 +3562,6 @@ int main(int argc, char *argv[]) {
   testGitHubIssue874();
   testGitHubIssue879();
   testGitHubIssue1496();
-  testAtomPairFPGenerator();
 #endif
   testGitHubIssue1793();
 

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -1,0 +1,72 @@
+
+
+#include <RDGeneral/RDLog.h>
+#include <GraphMol/RDKitBase.h>
+#include <RDBoost/test.h>
+#include <GraphMol/Fingerprints/AtomPairs.h>
+#include <GraphMol/Fingerprints/AtomPairGenerator.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+using namespace RDKit;
+
+void testAtomPairFPGenerator() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Test compatibility between atom pair "
+                           "implementation for FingerprintGenerator"
+                           " and old atom pairs implementation"
+                        << std::endl;
+  {
+    ROMol *mol;
+    SparseIntVect<boost::int32_t> *fp1, *fp2;
+    SparseIntVect<boost::uint32_t> *fpu;
+
+    FingerprintGenerator atomPairGenerator = AtomPair::getAtomPairGenerator();
+
+    mol = SmilesToMol("CCC");
+    fp1 = AtomPairs::getAtomPairFingerprint(*mol);
+    fpu = atomPairGenerator.getFingerprint(*mol);
+    fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
+    std::map<boost::uint32_t, int> nz = fpu->getNonzeroElements();
+    for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
+         it != nz.end(); it++) {
+      fp2->setVal(static_cast<boost::int32_t>(it->first), it->second);
+    }
+
+    TEST_ASSERT(DiceSimilarity(*fp1, *fp2) == 1.0);
+    TEST_ASSERT(*fp1 == *fp2);
+
+    delete mol;
+    delete fp1;
+    delete fp2;
+    delete fpu;
+
+    mol = SmilesToMol("CC=O.Cl");
+    fp1 = AtomPairs::getAtomPairFingerprint(*mol);
+    fpu = atomPairGenerator.getFingerprint(*mol);
+    fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
+    nz = fpu->getNonzeroElements();
+    for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
+         it != nz.end(); it++) {
+      fp2->setVal(static_cast<boost::int32_t>(it->first), it->second);
+    }
+
+    TEST_ASSERT(DiceSimilarity(*fp1, *fp2) == 1.0);
+    TEST_ASSERT(*fp1 == *fp2);
+
+    delete mol;
+    delete fp1;
+    delete fp2;
+    delete fpu;
+
+    atomPairGenerator.cleanUpResources();
+  }
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  RDLog::InitLogs();
+  testAtomPairFPGenerator();
+
+  return 0;
+}

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -84,10 +84,10 @@ void testAtomPairFP() {
   SparseIntVect<std::uint32_t> *fp;
   std::uint32_t c1, c2, c3;
 
-  FingerprintGenerator atomPairGenerator = AtomPair::getAtomPairGenerator();
+  FingerprintGenerator *atomPairGenerator = AtomPair::getAtomPairGenerator();
 
   mol = SmilesToMol("CCC");
-  fp = atomPairGenerator.getFingerprint(*mol);
+  fp = atomPairGenerator->getFingerprint(*mol);
   TEST_ASSERT(fp->getTotalVal() == 3);
   TEST_ASSERT(fp->getNonzeroElements().size() == 2);
 
@@ -100,7 +100,7 @@ void testAtomPairFP() {
   delete mol;
   delete fp;
   mol = SmilesToMol("CC=O.Cl");
-  fp = atomPairGenerator.getFingerprint(*mol);
+  fp = atomPairGenerator->getFingerprint(*mol);
   TEST_ASSERT(fp->getTotalVal() == 3);
   TEST_ASSERT(fp->getNonzeroElements().size() == 3);
 
@@ -113,7 +113,8 @@ void testAtomPairFP() {
 
   delete mol;
   delete fp;
-  atomPairGenerator.cleanUpResources();
+  delete atomPairGenerator;
+
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
@@ -128,11 +129,11 @@ void testAtomPairOld() {
     SparseIntVect<boost::int32_t> *fp1, *fp2;
     SparseIntVect<boost::uint32_t> *fpu;
 
-    FingerprintGenerator atomPairGenerator = AtomPair::getAtomPairGenerator();
+    FingerprintGenerator *atomPairGenerator = AtomPair::getAtomPairGenerator();
 
     mol = SmilesToMol("CCC");
     fp1 = AtomPairs::getAtomPairFingerprint(*mol);
-    fpu = atomPairGenerator.getFingerprint(*mol);
+    fpu = atomPairGenerator->getFingerprint(*mol);
     fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
     std::map<boost::uint32_t, int> nz = fpu->getNonzeroElements();
     for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
@@ -150,7 +151,7 @@ void testAtomPairOld() {
 
     mol = SmilesToMol("CC=O.Cl");
     fp1 = AtomPairs::getAtomPairFingerprint(*mol);
-    fpu = atomPairGenerator.getFingerprint(*mol);
+    fpu = atomPairGenerator->getFingerprint(*mol);
     fp2 = new SparseIntVect<boost::int32_t>(fpu->size());
     nz = fpu->getNonzeroElements();
     for (std::map<boost::uint32_t, int>::iterator it = nz.begin();
@@ -165,8 +166,7 @@ void testAtomPairOld() {
     delete fp1;
     delete fp2;
     delete fpu;
-
-    atomPairGenerator.cleanUpResources();
+    delete atomPairGenerator;
 
     BOOST_LOG(rdErrorLog) << "  done" << std::endl;
   }
@@ -179,6 +179,6 @@ int main(int argc, char *argv[]) {
   testAtomCodes();
   testAtomPairFP();
   testAtomPairOld();
-  
+
   return 0;
 }

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -18,58 +18,58 @@ void testAtomCodes() {
   std::uint32_t c1, c2, c3;
 
   mol = SmilesToMol("C=C");
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) ==
-              AtomPair::getAtomCode(mol->getAtomWithIdx(1)));
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false) ==
+              AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false));
   tgt = 1 | (1 | 1 << AtomPair::numPiBits) << AtomPair::numBranchBits;
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false) == tgt);
   tgt = 1 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 1) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 1, false) == tgt);
 
   delete mol;
   mol = SmilesToMol("C#CO");
   tgt = 1 | 2 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false) == tgt);
   tgt = 2 | 2 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1)) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false) == tgt);
   tgt = 1 | 0 << AtomPair::numBranchBits |
         3 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2)) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false) == tgt);
 
   delete mol;
   mol = SmilesToMol("CC(O)C(O)(O)C");
   tgt = 1 | 0 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1), 2) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1), 2, false) == tgt);
   tgt = 2 | 0 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(3), 2) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(3), 2, false) == tgt);
 
   delete mol;
   mol = SmilesToMol("C=CC(=O)O");
   tgt = 0 | 0 << AtomPair::numBranchBits |
         3 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(4), 1) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(4), 1, false) == tgt);
   tgt = 3 | 1 << AtomPair::numBranchBits |
         1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
-  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2)) == tgt);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false) == tgt);
 
   delete mol;
 
   mol = SmilesToMol("CCCCC");
-  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
-  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
-  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false);
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false);
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false);
   tgt = 1 | (std::min(c1, c2) | std::max(c1, c2) << AtomPair::codeSize)
                 << AtomPair::numPathBits;
-  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c2, 1) == tgt);
-  TEST_ASSERT(AtomPair::getAtomPairCode(c2, c1, 1) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c2, 1, false) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c2, c1, 1, false) == tgt);
   tgt = 2 | (std::min(c1, c3) | std::max(c1, c3) << AtomPair::codeSize)
                 << AtomPair::numPathBits;
-  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c3, 2) == tgt);
-  TEST_ASSERT(AtomPair::getAtomPairCode(c3, c1, 2) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c3, 2, false) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c3, c1, 2, false) == tgt);
 
   delete mol;
 
@@ -91,11 +91,11 @@ void testAtomPairFP() {
   TEST_ASSERT(fp->getTotalVal() == 3);
   TEST_ASSERT(fp->getNonzeroElements().size() == 2);
 
-  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
-  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
-  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
-  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1)) == 2);
-  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2)) == 1);
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false);
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false);
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1, false)) == 2);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2, false)) == 1);
 
   delete mol;
   delete fp;
@@ -104,12 +104,12 @@ void testAtomPairFP() {
   TEST_ASSERT(fp->getTotalVal() == 3);
   TEST_ASSERT(fp->getNonzeroElements().size() == 3);
 
-  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
-  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
-  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
-  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1)) == 1);
-  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2)) == 1);
-  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c2, c3, 1)) == 1);
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false);
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false);
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1, false)) == 1);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2, false)) == 1);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c2, c3, 1, false)) == 1);
 
   delete mol;
   delete fp;
@@ -188,25 +188,31 @@ void testAtomPairOutput() {
       new std::vector<std::vector<std::uint64_t>>(mol->getNumAtoms());
   fp = atomPairGenerator->getFingerprint(*mol, nullptr, nullptr, -1,
                                          &additionalOutput);
-  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
-  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
-  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0), 0, false);
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1), 0, false);
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2), 0, false);
   std::cout << additionalOutput.atomToBits->at(0).empty() << std::endl;
   v = additionalOutput.atomToBits->at(0);
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c1, c2, 1))) != v.end());
+                        (AtomPair::getAtomPairCode(c1, c2, 1, false))) !=
+              v.end());
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c1, c3, 2))) != v.end());
+                        (AtomPair::getAtomPairCode(c1, c3, 2, false))) !=
+              v.end());
   v = additionalOutput.atomToBits->at(1);
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c1, c2, 1))) != v.end());
+                        (AtomPair::getAtomPairCode(c1, c2, 1, false))) !=
+              v.end());
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c2, c3, 1))) != v.end());
+                        (AtomPair::getAtomPairCode(c2, c3, 1, false))) !=
+              v.end());
   v = additionalOutput.atomToBits->at(2);
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c1, c3, 2))) != v.end());
+                        (AtomPair::getAtomPairCode(c1, c3, 2, false))) !=
+              v.end());
   TEST_ASSERT(std::find(v.begin(), v.end(),
-                        (AtomPair::getAtomPairCode(c2, c3, 1))) != v.end());
+                        (AtomPair::getAtomPairCode(c2, c3, 1, false))) !=
+              v.end());
 
   delete mol;
   delete fp;

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -9,7 +9,115 @@
 
 using namespace RDKit;
 
-void testAtomPairFPGenerator() {
+void testAtomCodes() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Test atom codes AtomPairGenerator" << std::endl;
+
+  ROMol *mol;
+  std::uint32_t tgt;
+  std::uint32_t c1, c2, c3;
+
+  mol = SmilesToMol("C=C");
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) ==
+              AtomPair::getAtomCode(mol->getAtomWithIdx(1)));
+  tgt = 1 | (1 | 1 << AtomPair::numPiBits) << AtomPair::numBranchBits;
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) == tgt);
+  tgt = 1 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0), 1) == tgt);
+
+  delete mol;
+  mol = SmilesToMol("C#CO");
+  tgt = 1 | 2 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(0)) == tgt);
+  tgt = 2 | 2 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1)) == tgt);
+  tgt = 1 | 0 << AtomPair::numBranchBits |
+        3 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2)) == tgt);
+
+  delete mol;
+  mol = SmilesToMol("CC(O)C(O)(O)C");
+  tgt = 1 | 0 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(1), 2) == tgt);
+  tgt = 2 | 0 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(3), 2) == tgt);
+
+  delete mol;
+  mol = SmilesToMol("C=CC(=O)O");
+  tgt = 0 | 0 << AtomPair::numBranchBits |
+        3 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(4), 1) == tgt);
+  tgt = 3 | 1 << AtomPair::numBranchBits |
+        1 << (AtomPair::numBranchBits + AtomPair::numPiBits);
+  TEST_ASSERT(AtomPair::getAtomCode(mol->getAtomWithIdx(2)) == tgt);
+
+  delete mol;
+
+  mol = SmilesToMol("CCCCC");
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  tgt = 1 | (std::min(c1, c2) | std::max(c1, c2) << AtomPair::codeSize)
+                << AtomPair::numPathBits;
+  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c2, 1) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c2, c1, 1) == tgt);
+  tgt = 2 | (std::min(c1, c3) | std::max(c1, c3) << AtomPair::codeSize)
+                << AtomPair::numPathBits;
+  TEST_ASSERT(AtomPair::getAtomPairCode(c1, c3, 2) == tgt);
+  TEST_ASSERT(AtomPair::getAtomPairCode(c3, c1, 2) == tgt);
+
+  delete mol;
+
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
+void testAtomPairFP() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Test atom-pair fp generator" << std::endl;
+
+  ROMol *mol;
+  SparseIntVect<std::uint32_t> *fp;
+  std::uint32_t c1, c2, c3;
+
+  FingerprintGenerator atomPairGenerator = AtomPair::getAtomPairGenerator();
+
+  mol = SmilesToMol("CCC");
+  fp = atomPairGenerator.getFingerprint(*mol);
+  TEST_ASSERT(fp->getTotalVal() == 3);
+  TEST_ASSERT(fp->getNonzeroElements().size() == 2);
+
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1)) == 2);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2)) == 1);
+
+  delete mol;
+  delete fp;
+  mol = SmilesToMol("CC=O.Cl");
+  fp = atomPairGenerator.getFingerprint(*mol);
+  TEST_ASSERT(fp->getTotalVal() == 3);
+  TEST_ASSERT(fp->getNonzeroElements().size() == 3);
+
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c2, 1)) == 1);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c1, c3, 2)) == 1);
+  TEST_ASSERT(fp->getVal(AtomPair::getAtomPairCode(c2, c3, 1)) == 1);
+
+  delete mol;
+  delete fp;
+  atomPairGenerator.cleanUpResources();
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
+void testAtomPairOld() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "Test compatibility between atom pair "
                            "implementation for FingerprintGenerator"
@@ -59,6 +167,8 @@ void testAtomPairFPGenerator() {
     delete fpu;
 
     atomPairGenerator.cleanUpResources();
+
+    BOOST_LOG(rdErrorLog) << "  done" << std::endl;
   }
 }
 
@@ -66,7 +176,9 @@ int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
-  testAtomPairFPGenerator();
-
+  testAtomCodes();
+  testAtomPairFP();
+  testAtomPairOld();
+  
   return 0;
 }

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -172,6 +172,48 @@ void testAtomPairOld() {
   }
 }
 
+void testAtomPairOutput() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "Test atom-pair additional output" << std::endl;
+
+  ROMol *mol;
+  SparseIntVect<std::uint32_t> *fp;
+  std::uint32_t c1, c2, c3;
+  AdditionalOutput additionalOutput = {nullptr, nullptr, nullptr, nullptr};
+  std::vector<std::uint64_t> v;
+
+  FingerprintGenerator *atomPairGenerator = AtomPair::getAtomPairGenerator();
+  mol = SmilesToMol("CCC");
+  additionalOutput.atomToBits =
+      new std::vector<std::vector<std::uint64_t>>(mol->getNumAtoms());
+  fp = atomPairGenerator->getFingerprint(*mol, nullptr, nullptr, -1,
+                                         &additionalOutput);
+  c1 = AtomPair::getAtomCode(mol->getAtomWithIdx(0));
+  c2 = AtomPair::getAtomCode(mol->getAtomWithIdx(1));
+  c3 = AtomPair::getAtomCode(mol->getAtomWithIdx(2));
+  std::cout << additionalOutput.atomToBits->at(0).empty() << std::endl;
+  v = additionalOutput.atomToBits->at(0);
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c1, c2, 1))) != v.end());
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c1, c3, 2))) != v.end());
+  v = additionalOutput.atomToBits->at(1);
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c1, c2, 1))) != v.end());
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c2, c3, 1))) != v.end());
+  v = additionalOutput.atomToBits->at(2);
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c1, c3, 2))) != v.end());
+  TEST_ASSERT(std::find(v.begin(), v.end(),
+                        (AtomPair::getAtomPairCode(c2, c3, 1))) != v.end());
+
+  delete mol;
+  delete fp;
+  delete additionalOutput.atomToBits;
+  delete atomPairGenerator;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -179,6 +221,7 @@ int main(int argc, char *argv[]) {
   testAtomCodes();
   testAtomPairFP();
   testAtomPairOld();
+  testAtomPairOutput();
 
   return 0;
 }


### PR DESCRIPTION
@greglandrum @NadineSchneider @AndreaVolkamer
Atom pairs implementation using base classes that FingerprintGenerator can use. Has one test that compares old implementation results with the new, both using default arguments and without invariants or fromAtoms, ignoreAtoms arguments. I will update the PR with more tests and folded fingerprint implementation if this approach is good
