### PR TITLE
Fix some abstract base class method definition problems

### DIFF
--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -95,9 +95,8 @@ OutputType AtomPairAtomEnv<OutputType>::getBitId(
   std::uint32_t atomCodeSecond =
       (*atomInvariants)[d_atomIdSecond] % codeSizeLimit;
 
-  std::uint32_t bitId;
+  std::uint32_t bitId = 0;
   if (hashResults) {
-    boost::uint32_t bit = 0;
     gboost::hash_combine(bitId, std::min(atomCodeFirst, atomCodeSecond));
     gboost::hash_combine(bitId, d_distance);
     gboost::hash_combine(bitId, std::max(atomCodeFirst, atomCodeSecond));

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -35,31 +35,6 @@ std::string FingerprintArguments<OutputType>::commonArgumentsString() const {
 }
 
 template <typename OutputType>
-FingerprintArguments<OutputType>::~FingerprintArguments() {}
-
-template FingerprintArguments<std::uint32_t>::~FingerprintArguments();
-
-template FingerprintArguments<std::uint64_t>::~FingerprintArguments();
-
-template <typename OutputType>
-AtomEnvironmentGenerator<OutputType>::~AtomEnvironmentGenerator() {}
-
-template AtomEnvironmentGenerator<std::uint32_t>::~AtomEnvironmentGenerator();
-template AtomEnvironmentGenerator<std::uint64_t>::~AtomEnvironmentGenerator();
-
-template <typename OutputType>
-AtomEnvironment<OutputType>::~AtomEnvironment() {}
-
-template AtomEnvironment<std::uint32_t>::~AtomEnvironment();
-template AtomEnvironment<std::uint64_t>::~AtomEnvironment();
-
-AtomInvariantsGenerator::~AtomInvariantsGenerator() {}
-AtomInvariantsGenerator *AtomInvariantsGenerator::clone() const {}
-
-BondInvariantsGenerator::~BondInvariantsGenerator() {}
-BondInvariantsGenerator *BondInvariantsGenerator::clone() const {}
-
-template <typename OutputType>
 FingerprintGenerator<OutputType>::FingerprintGenerator(
     AtomEnvironmentGenerator<OutputType> *atomEnvironmentGenerator,
     FingerprintArguments<OutputType> *fingerprintArguments,

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -70,7 +70,7 @@ class FingerprintArguments : private boost::noncopyable {
    */
   std::string commonArgumentsString() const;
 
-  virtual ~FingerprintArguments() = 0;
+  virtual ~FingerprintArguments(){};
 };
 
 /*!
@@ -98,7 +98,7 @@ class AtomEnvironment : private boost::noncopyable {
                               const AdditionalOutput *AdditionalOutput,
                               const bool hashResults = false) const = 0;
 
-  virtual ~AtomEnvironment() = 0;
+  virtual ~AtomEnvironment(){};
 };
 
 /*!
@@ -152,7 +152,7 @@ class AtomEnvironmentGenerator : private boost::noncopyable {
    */
   virtual std::string infoString() const = 0;
 
-  virtual ~AtomEnvironmentGenerator() = 0;
+  virtual ~AtomEnvironmentGenerator(){};
 };
 
 /*!
@@ -180,7 +180,7 @@ class AtomInvariantsGenerator : private boost::noncopyable {
    */
   virtual std::string infoString() const = 0;
 
-  virtual ~AtomInvariantsGenerator() = 0;
+  virtual ~AtomInvariantsGenerator(){};
   virtual AtomInvariantsGenerator *clone() const = 0;
 };
 
@@ -209,9 +209,9 @@ class BondInvariantsGenerator : private boost::noncopyable {
  */
   virtual std::string infoString() const = 0;
 
-  virtual ~BondInvariantsGenerator() = 0;
+  virtual ~BondInvariantsGenerator(){};
   virtual BondInvariantsGenerator *clone() const = 0;
-};
+};  // namespace RDKit
 
 /*!
   /brief class that generates same fingerprint style for different output

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -80,6 +80,7 @@ class MorganBondInvGenerator : public BondInvariantsGenerator {
 
   std::string infoString() const;
   MorganBondInvGenerator *clone() const;
+  ~MorganBondInvGenerator(){};
 };
 
 /**
@@ -133,7 +134,8 @@ class MorganAtomEnv : public AtomEnvironment<OutputType> {
   OutputType getBitId(FingerprintArguments<OutputType> *arguments,
                       const std::vector<std::uint32_t> *atomInvariants,
                       const std::vector<std::uint32_t> *bondInvariants,
-                      const AdditionalOutput *additionalOutput, const bool hashResults = false) const;
+                      const AdditionalOutput *additionalOutput,
+                      const bool hashResults = false) const;
 
   /**
    /brief Construct a new MorganAtomEnv object
@@ -159,7 +161,8 @@ class MorganEnvGenerator : public AtomEnvironmentGenerator<OutputType> {
       const std::vector<std::uint32_t> *ignoreAtoms, const int confId,
       const AdditionalOutput *additionalOutput,
       const std::vector<std::uint32_t> *atomInvariants,
-      const std::vector<std::uint32_t> *bondInvariants, const bool hashResults = false) const;
+      const std::vector<std::uint32_t> *bondInvariants,
+      const bool hashResults = false) const;
 
   std::string infoString() const;
 };
@@ -179,19 +182,16 @@ class MorganEnvGenerator : public AtomEnvironmentGenerator<OutputType> {
  /param countBounds : boundaries for count simulation, corresponding bit will be
  set if the count is higher than the number provided for that spot
  /param foldedSize : size of the folded version of the fingerprints
- /param countSimulation : if set, use count simulation while generating the fingerprint
- /param includeChirality : sets includeChirality flag for both MorganArguments
- and the default bond generator MorganBondInvGenerator
- /param useBondTypes : if set, bond types will be included as a part of the
- default bond invariants
- /param onlyNonzeroInvariants : if set, bits will only be set from atoms that
- have a nonzero invariant
- /param atomInvariantsGenerator : custom atom invariants generator to use
- /param bondInvariantsGenerator : custom bond invariants generator to use
- /param ownsAtomInvGen  if set atom invariants generator is destroyed with the
- fingerprint generator
- /param ownsBondInvGen  if set bond invariants generator is destroyed with the
- fingerprint generator
+ /param countSimulation : if set, use count simulation while generating the
+ fingerprint /param includeChirality : sets includeChirality flag for both
+ MorganArguments and the default bond generator MorganBondInvGenerator /param
+ useBondTypes : if set, bond types will be included as a part of the default
+ bond invariants /param onlyNonzeroInvariants : if set, bits will only be set
+ from atoms that have a nonzero invariant /param atomInvariantsGenerator :
+ custom atom invariants generator to use /param bondInvariantsGenerator : custom
+ bond invariants generator to use /param ownsAtomInvGen  if set atom invariants
+ generator is destroyed with the fingerprint generator /param ownsBondInvGen  if
+ set bond invariants generator is destroyed with the fingerprint generator
 
  /return FingerprintGenerator<OutputType>* that generates Morgan fingerprints
  */

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -170,7 +170,7 @@ class MorganEnvGenerator : public AtomEnvironmentGenerator<OutputType> {
 /**
  /brief Get a fingerprint generator for Morgan fingerprint
 
- /tparam OutputType determines the size of the bitIds and the result, can be 32
+ /param OutputType determines the size of the bitIds and the result, can be 32
  or 64 bit unsigned integer
  /param radius : the number of iterations to grow the fingerprint
  /param countSimulation : if set, use count simulation while generating the
@@ -183,14 +183,21 @@ class MorganEnvGenerator : public AtomEnvironmentGenerator<OutputType> {
  set if the count is higher than the number provided for that spot
  /param foldedSize : size of the folded version of the fingerprints
  /param countSimulation : if set, use count simulation while generating the
- fingerprint /param includeChirality : sets includeChirality flag for both
- MorganArguments and the default bond generator MorganBondInvGenerator /param
+ fingerprint
+ /param includeChirality : sets includeChirality flag for both
+ MorganArguments and the default bond generator MorganBondInvGenerator
+ /param
  useBondTypes : if set, bond types will be included as a part of the default
- bond invariants /param onlyNonzeroInvariants : if set, bits will only be set
- from atoms that have a nonzero invariant /param atomInvariantsGenerator :
- custom atom invariants generator to use /param bondInvariantsGenerator : custom
- bond invariants generator to use /param ownsAtomInvGen  if set atom invariants
- generator is destroyed with the fingerprint generator /param ownsBondInvGen  if
+ bond invariants
+ /param onlyNonzeroInvariants : if set, bits will only be set
+ from atoms that have a nonzero invariant
+ /param atomInvariantsGenerator :
+ custom atom invariants generator to use
+ /param bondInvariantsGenerator : custom
+ bond invariants generator to use
+ /param ownsAtomInvGen  if set atom invariants
+ generator is destroyed with the fingerprint generator
+ /param ownsBondInvGen  if
  set bond invariants generator is destroyed with the fingerprint generator
 
  /return FingerprintGenerator<OutputType>* that generates Morgan fingerprints

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -172,33 +172,44 @@ class MorganEnvGenerator : public AtomEnvironmentGenerator<OutputType> {
 
  /param OutputType determines the size of the bitIds and the result, can be 32
  or 64 bit unsigned integer
+
  /param radius : the number of iterations to grow the fingerprint
+
  /param countSimulation : if set, use count simulation while generating the
  fingerprint
+
  /param includeChirality : if set, chirality information will be added to the
  generated bit id, independently from bond invariants
+
  /param onlyNonzeroInvariants : if set, bits will only be set from atoms that
  have a nonzero invariant
+
  /param countBounds : boundaries for count simulation, corresponding bit will be
  set if the count is higher than the number provided for that spot
+
  /param foldedSize : size of the folded version of the fingerprints
+
  /param countSimulation : if set, use count simulation while generating the
  fingerprint
- /param includeChirality : sets includeChirality flag for both
- MorganArguments and the default bond generator MorganBondInvGenerator
- /param
- useBondTypes : if set, bond types will be included as a part of the default
- bond invariants
- /param onlyNonzeroInvariants : if set, bits will only be set
- from atoms that have a nonzero invariant
- /param atomInvariantsGenerator :
- custom atom invariants generator to use
- /param bondInvariantsGenerator : custom
- bond invariants generator to use
- /param ownsAtomInvGen  if set atom invariants
- generator is destroyed with the fingerprint generator
- /param ownsBondInvGen  if
- set bond invariants generator is destroyed with the fingerprint generator
+
+ /param includeChirality : sets includeChirality flag for both MorganArguments
+ and the default bond generator MorganBondInvGenerator
+
+ /param useBondTypes : if set, bond types will be included as a part of the
+ default bond invariants
+
+ /param onlyNonzeroInvariants : if set, bits will only be set from atoms that
+ have a nonzero invariant
+
+ /param atomInvariantsGenerator : custom atom invariants generator to use
+
+ /param bondInvariantsGenerator : custom  bond invariants generator to use
+
+ /param ownsAtomInvGen  if set atom invariants  generator is destroyed with the
+ fingerprint generator
+
+ /param ownsBondInvGen  if set bond invariants generator is destroyed with the
+ fingerprint generator
 
  /return FingerprintGenerator<OutputType>* that generates Morgan fingerprints
  */

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -2395,6 +2395,7 @@ int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
+#if 1
   testAtomPairFP();
   testAtomPairArgs();
   testAtomPairOld();
@@ -2425,6 +2426,7 @@ int main(int argc, char *argv[]) {
   testIgnoreTorsions();
   testPairsAndTorsionsOptions();
   testChiralTorsions();
+#endif
   testGitHubIssue25();
   testGitHubIssue334();
   testGitHubIssue811();


### PR DESCRIPTION
You had some empty implementations of methods that had been disabled that caused problems with Windows builds. This clears those up and also moves empty method definitions into the header files.
I also fixed a use of uninitialized memory that was causing problems on Windows and, I think, the travis builds.